### PR TITLE
build: fix include path to QtAdMob

### DIFF
--- a/AdCtl.pri
+++ b/AdCtl.pri
@@ -1,4 +1,4 @@
-ADMOB_PATH = $$PWD/3rd/QtAdMob/QtAdMob
+ADMOB_PATH = $$PWD/3rd/QtAdMob
 GOOGLE_ANALITICS_PATH = $$PWD/3rd/qt-google-analytics
 
 include($$ADMOB_PATH/QtAdMob.pri)


### PR DESCRIPTION
Correct ADMOB_PATH in AdCtl.pri
